### PR TITLE
feat: header event

### DIFF
--- a/context.ts
+++ b/context.ts
@@ -146,12 +146,21 @@ export class XMLParseContext {
     private _memento = '';
     private _elementStack: Element[] = [];
     private _namespaces: { [ns: string]: string | undefined } = {};
+    private _collectHeader = false;
 
     quote: '' | '"' | '\'' = '';
     state = 'BEFORE_DOCUMENT';
 
     constructor(locator?: XMLLocator) {
         this._locator = locator;
+    }
+
+    setOption({ collectHeader }: ParserOptions) {
+        this._collectHeader = collectHeader;
+    }
+    
+    get options(): ParserOptions {
+        return { collectHeader: this._collectHeader };
     }
 
     get position(): XMLPosition {
@@ -224,4 +233,8 @@ export class XMLParseError extends Error {
     get column(): number {
         return this._position.column;
     }
+}
+
+export type ParserOptions = {
+    collectHeader: boolean;
 }

--- a/context.ts
+++ b/context.ts
@@ -200,8 +200,7 @@ export class XMLParseContext {
     }
 }
 
-// deno-lint-ignore no-explicit-any
-export type XMLParseEvent = [string, ...any[]];
+export type XMLParseEvent = [string, ...unknown[]];
 
 export interface XMLParseHandler {
     (cx: XMLParseContext, c: string): XMLParseEvent[];

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,0 @@
-// Copyright 2020 Masataka Kurihara. All rights reserved. MIT license.
-
-export {
-    readableStreamFromReader,
-} from 'https://deno.land/std@0.140.0/streams/conversion.ts';

--- a/dev_deps.ts
+++ b/dev_deps.ts
@@ -1,7 +1,5 @@
 // Copyright 2020 Masataka Kurihara. All rights reserved. MIT license.
 
-export {
-    assert,
-    assertEquals,
-    assertThrows,
-} from 'https://deno.land/std@0.140.0/testing/asserts.ts';
+export { assert } from 'https://deno.land/std@0.204.0/assert/assert.ts'
+export { assertEquals } from 'https://deno.land/std@0.204.0/assert/assert_equals.ts'
+export { assertThrows } from 'https://deno.land/std@0.204.0/assert/assert_throws.ts';

--- a/handler.ts
+++ b/handler.ts
@@ -34,8 +34,19 @@ export function resolveEntity(text: string): string {
 
 // BEFORE_DOCUMENT; FOUND_LT, Error
 export function handleBeforeDocument(cx: XMLParseContext, c: string): XMLParseEvent[] {
+    const { collectHeader } = cx.options;
+
     if (c === '<') {
         cx.state = 'FOUND_LT';
+        const header = cx.memento;
+        if (header) {
+            cx.clearMemento();
+            return [['header', header]];
+        }
+    }
+
+    if (collectHeader) {
+        cx.appendMemento(c)
     } else {
         if (!isWhitespace(c)) {
             throw new XMLParseError('Non-whitespace before document.', cx);

--- a/parser.ts
+++ b/parser.ts
@@ -1,10 +1,6 @@
 // Copyright 2020 Masataka Kurihara. All rights reserved. MIT license.
 
 import {
-    readableStreamFromReader,
- } from './deps.ts';
-
-import {
     XMLParseHandler,
     XMLParseContext,
     XMLParseEvent,
@@ -245,7 +241,7 @@ export class SAXParser extends ParserBase implements UnderlyingSink<Uint8Array> 
      * @param source Target XML.
      * @param encoding When the source is Deno.Reader or Uint8Array, specify the encoding.
      */
-    async parse(source: Deno.Reader | Uint8Array | string, encoding?: string) {
+    async parse(source: ReadableStream<unknown> | Uint8Array | string, encoding?: string) {
         this._encoding = encoding;
         if (typeof source === 'string') {
             this.chunk = source;
@@ -253,8 +249,8 @@ export class SAXParser extends ParserBase implements UnderlyingSink<Uint8Array> 
         } else if (source instanceof Uint8Array) {
             this.write(source);
         } else {
-            await readableStreamFromReader(source).pipeThrough(
-                new TextDecoderStream(this._encoding),
+            await source.pipeThrough(
+                new TextDecoderStream(this._encoding)
             ).pipeTo(
                 new WritableStream<string>({ write: str => this.parse(str, encoding) }),
             );

--- a/parser.ts
+++ b/parser.ts
@@ -293,22 +293,24 @@ export class PullParser extends ParserBase {
         const name = event[0];
         const result: PullResult = { name };
         if (name === 'processing_instruction') {
-            result['procInst'] = event[1];
+            result['procInst'] = event[1] as string;
         } else if (name === 'sgml_declaration') {
-            result['sgmlDecl'] = event[1];
+            result['sgmlDecl'] = event[1] as string;
         } else if (name === 'text') {
-            result['text'] = event[1];
-            result['element'] = event[2];
-            result['cdata'] = event[3];
+            result['text'] = event[1] as string;
+            result['element'] = event[2] as ElementInfo;
+            result['cdata'] = event[3] as boolean;
         } else if (name === 'doctype') {
-            result['doctype'] = event[1];
+            result['doctype'] = event[1] as string;
         } else if (name === 'start_prefix_mapping' || name === 'end_prefix_mapping') {
-            result['ns'] = event[1];
-            result['uri'] = event[2];
+            result['ns'] = event[1] as string;
+            result['uri'] = event[2] as string;
         } else if (name === 'start_element' || name === 'end_element') {
-            result['element'] = event[1];
+            result['element'] = event[1] as ElementInfo;
         } else if (name === 'comment') {
-            result['comment'] = event[1];
+            result['comment'] = event[1] as string;
+        } else if (name === 'header') {
+            result['header'] = event[1] as string;
         }
         return result;
     }

--- a/parser.ts
+++ b/parser.ts
@@ -8,6 +8,7 @@ import {
     XMLLocator,
     XMLPosition,
     ElementInfo,
+    ParserOptions,
 } from './context.ts';
 
 import {
@@ -157,6 +158,7 @@ export interface SAXEvent {
     end_prefix_mapping: (ns: string, uri: string) => void;
     end_document: () => void;
     error: (error: XMLParseError) => void;
+    header: (header: string) => void;
 }
 
 /**
@@ -167,6 +169,11 @@ export class SAXParser extends ParserBase implements UnderlyingSink<Uint8Array> 
     private _listeners: { [name: string]: ((...arg: any[]) => void)[] } = {};
     private _controller?: WritableStreamDefaultController;
     private _encoding?: string;
+
+    constructor({ collectHeader = false }: Partial<ParserOptions> = {}) {
+        super();
+        this.cx.setOption({collectHeader});
+    }
 
     protected fireListeners(event: XMLParseEvent) {
         const [name, ...args] = event;
@@ -283,6 +290,7 @@ export interface PullResult {
     uri?: string;
     comment?: string;
     error?: XMLParseError;
+    header?: string;
 }
 
 /**

--- a/parser_test.ts
+++ b/parser_test.ts
@@ -69,7 +69,7 @@ Deno.test('SAXParser on & parse(Deno.Reader)', async () => {
         }
     });
     const file = await Deno.open('parser_test.xml');
-    await parser.parse(file);
+    await parser.parse(file.readable);
     assertEquals(assertionCount, 3);
     assertEquals(elementCount, 18);
 });


### PR DESCRIPTION
Support data before xml root emitting `header` event.

This allows for parsing of OFX files. A file type used to describe financial transactions.

also bumps (dependency) Deno std library version.